### PR TITLE
Some improve

### DIFF
--- a/tgiann-attachproptoplayereditor/client/client.lua
+++ b/tgiann-attachproptoplayereditor/client/client.lua
@@ -138,7 +138,10 @@ function finish()
     end
     FreezeEntityPosition(PlayerPedId(), false)
     ClearPedTasks(PlayerPedId())
-    SetEntityCoords(PlayerPedId(), lastCoord)
+    if lastCoord ~= nil then
+        SetEntityCoords(PlayerPedId(), lastCoord)
+        lastCoord = nil
+    end
 end
 
 function taskPlayAnim(ped, dict, anim, flag)

--- a/tgiann-attachproptoplayereditor/client/client.lua
+++ b/tgiann-attachproptoplayereditor/client/client.lua
@@ -53,7 +53,7 @@ function useGizmo(handle, boneid, dict, anim)
     end
 
     finish()
-    return (extraZ-position.z)..", "..position.y..", "..position.x..", "..rotation.x..", "..rotation.y..", "..rotation.z
+    return "AttachEntityToEntity(entity,PlayerPedId(),"..pedBoneId.." ,"..(extraZ-position.z)..", "..position.y..", "..position.x..", "..rotation.x..", "..rotation.y..", "..rotation.z..", 1, 1, 0, 1, 0, 1)"
 end
 
 RegisterNUICallback('moveEntity', function(data, cb)

--- a/tgiann-attachproptoplayereditor/client/client.lua
+++ b/tgiann-attachproptoplayereditor/client/client.lua
@@ -22,7 +22,7 @@ function useGizmo(handle, boneid, dict, anim)
     SetEntityHeading(playerPed, 0.0)
     SetEntityRotation(pedBoneId, 0.0, 0.0, 0.0)
     position, rotation = vector3(0.0, 0.0, 0.0), vector3(0.0, 0.0, 0.0)
-    AttachEntityToEntity(spawnedProp, playerPed, pedBoneId, position, rotation, true, true, false, true, 1, true)
+    AttachEntityToEntity(spawnedProp, playerPed, pedBoneId, position, rotation, true, true, false, true, 0, true)
 
     SendNUIMessage({
         action = 'setGizmoEntity',

--- a/tgiann-attachproptoplayereditor/client/client.lua
+++ b/tgiann-attachproptoplayereditor/client/client.lua
@@ -22,7 +22,7 @@ function useGizmo(handle, boneid, dict, anim)
     SetEntityHeading(playerPed, 0.0)
     SetEntityRotation(pedBoneId, 0.0, 0.0, 0.0)
     position, rotation = vector3(0.0, 0.0, 0.0), vector3(0.0, 0.0, 0.0)
-    AttachEntityToEntity(spawnedProp, playerPed, pedBoneId, position, rotation, true, true, false, true, 0, true)
+    AttachEntityToEntity(spawnedProp, playerPed, pedBoneId, position, rotation, true, true, false, true, 1, true)
 
     SendNUIMessage({
         action = 'setGizmoEntity',
@@ -53,14 +53,17 @@ function useGizmo(handle, boneid, dict, anim)
     end
 
     finish()
-    return "AttachEntityToEntity(entity,PlayerPedId(),"..pedBoneId.." ,"..(extraZ-position.z)..", "..position.y..", "..position.x..", "..rotation.x..", "..rotation.y..", "..rotation.z..", 1, 1, 0, 1, 0, 1)"
+    return {
+        "AttachEntityToEntity(entity, PlayerPedId(), "..pedBoneId..", "..(extraZ-position.z)..", "..position.y..", "..position.x..", "..rotation.x..", "..rotation.y..", "..rotation.z..", true, true, false, true, 1, true)",
+        (extraZ-position.z)..", "..position.y..", "..position.x..", "..rotation.x..", "..rotation.y..", "..rotation.z
+    }
 end
 
 RegisterNUICallback('moveEntity', function(data, cb)
     local entity = data.handle
     position = data.position
     rotation = data.rotation
-    AttachEntityToEntity(entity, PlayerPedId(), pedBoneId, extraZ-position.z, position.y, position.x, rotation.x, rotation.y, rotation.z, 1, 1, 0, 1, 0, 1)
+    AttachEntityToEntity(entity, PlayerPedId(), pedBoneId, extraZ-position.z, position.y, position.x, rotation.x, rotation.y, rotation.z, true, true, false, true, 1, true) --Same attach settings as dp emote and rp emotes
     cb('ok')
 end)
 
@@ -136,10 +139,11 @@ function finish()
     if DoesEntityExist(spawnedProp) then
         DeleteEntity(spawnedProp)
     end
-    FreezeEntityPosition(PlayerPedId(), false)
-    ClearPedTasks(PlayerPedId())
-    if lastCoord ~= nil then
-        SetEntityCoords(PlayerPedId(), lastCoord)
+    local playerPed = PlayerPedId()
+    FreezeEntityPosition(playerPed, false)
+    ClearPedTasks(playerPed)
+    if lastCoord then
+        SetEntityCoords(playerPed, lastCoord)
         lastCoord = nil
     end
 end

--- a/tgiann-attachproptoplayereditor/client/command.lua
+++ b/tgiann-attachproptoplayereditor/client/command.lua
@@ -1,15 +1,14 @@
+--Example: /prop prop_sandwich_01 18905 mp_player_inteat@burger mp_player_int_eat_burger
 RegisterCommand('prop',function(source, args, rawCommand)
     local model = joaat(args[1] or "prop_cs_burger_01")
     if not HasModelLoaded(model) then RequestModel(model) while not HasModelLoaded(model) do Wait(1) end end
     local playerPed = PlayerPedId()
     local playerCoords = GetEntityCoords(playerPed)
     local object = CreateObject(model, playerCoords.x, playerCoords.y, playerCoords.z, false, false, false)
-    local bone = 18905
-    if args[2] and tonumber(args[2]) ~= nil then
-        bone = GetPedBoneIndex(playerPed, tonumber(args[2]))
-    elseif args[2] then
-        bone =  GetEntityBoneIndexByName(playerPed, args[2] )
-    end
+    local boneArg = args[2]
+    local boneToNumber = tonumber(boneArg)
+    local bone = (boneArg and boneToNumber) and GetPedBoneIndex(playerPed, boneToNumber) or boneArg and GetEntityBoneIndexByName(playerPed, boneArg) or 18905
     local objectPositionData = useGizmo(object, bone, args[3], args[4])
-    print(objectPositionData)
+    print(objectPositionData[1])
+    print(objectPositionData[2])
 end)

--- a/tgiann-attachproptoplayereditor/client/command.lua
+++ b/tgiann-attachproptoplayereditor/client/command.lua
@@ -4,6 +4,12 @@ RegisterCommand('prop',function(source, args, rawCommand)
     local playerPed = PlayerPedId()
     local playerCoords = GetEntityCoords(playerPed)
     local object = CreateObject(model, playerCoords.x, playerCoords.y, playerCoords.z, false, false, false)
-    local objectPositionData = useGizmo(object, (args[2] and GetPedBoneIndex(playerPed, tonumber(args[2])) or 18905), args[3], args[4])
+    local bone = 18905
+    if args[2] and tonumber(args[2]) ~= nil then
+        bone = GetPedBoneIndex(playerPed, tonumber(args[2]))
+    elseif args[2] then
+        bone =  GetEntityBoneIndexByName(playerPed, args[2] )
+    end
+    local objectPositionData = useGizmo(object, bone, args[3], args[4])
     print(objectPositionData)
 end)


### PR DESCRIPTION
-use either boneid or bonename in the command
-use of the same rotationorder in initialization as in nuicallback
-Tp player only if needed (don tp player on 0,0,0 if never used command before or already finish and stop the ressource)

- alternate return print (the full native with value, better for copy past value)